### PR TITLE
Fixed bug in Windows

### DIFF
--- a/wordcut/__init__.py
+++ b/wordcut/__init__.py
@@ -201,7 +201,7 @@ class Wordcut(object):
         "Initialize from bigthai"
         fileDir =  os.path.dirname(__file__)
         filename = os.path.join(fileDir, 'bigthai.txt')
-        with open(filename) as dict_file:
+        with open(filename, 'r', encoding = 'utf-8-sig') as dict_file:
 
             word_list = list(set([w.rstrip() for w in dict_file.readlines()]))
             word_list.sort()


### PR DESCRIPTION
Fixed bug in Windows

```
>>> from wordcut import Wordcut
>>> wordcut = Wordcut.bigthai()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\TC\Anaconda3\lib\site-packages\wordcut\__init__.py", line 206, in bigthai
    word_list = list(set([w.rstrip() for w in dict_file.readlines()]))
  File "C:\Users\TC\Anaconda3\lib\encodings\cp874.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 2: character maps to <undefined>
```